### PR TITLE
chore(auth): Show necessary hack for current auth workflow

### DIFF
--- a/backend-py/src/api/middleware/verify_sentry_signature.py
+++ b/backend-py/src/api/middleware/verify_sentry_signature.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import json
 import os
 import functools
 from typing import Any, Mapping
@@ -15,6 +14,10 @@ from src import app
 load_dotenv()
 FLASK_ENV = os.getenv("FLASK_ENV")
 SENTRY_CLIENT_SECRET = os.getenv("SENTRY_CLIENT_SECRET")
+
+# There are few hacks in this verification step (denoted with HACK) that we at Sentry hope
+# to migrate away from in the future. Presently however, for legacy reasons, they are
+# necessary to keep around, so we've shown how to deal with them here.
 
 
 def is_correct_sentry_signature(
@@ -38,22 +41,26 @@ def is_correct_sentry_signature(
 def verify_sentry_signature():
     """
     This function will authenticate that the requests are coming from Sentry.
-    Now we can be confident in our nested routes that the data is legit,
-    without having to repeat this check.
+    It allows us to be confident that all the code run after this middleware are
+    using verified data sent directly from Sentry.
     """
     def wrapper(f):
         @functools.wraps(f)
         def inner(*args: Any, **kwargs: Any):
-
+            # HACK: We need to use the raw request body since Flask will throw a 400 Bad Request
+            # if we try to use request.json. This is because Sentry sends an empty body (i.e. b'')
+            # with a Content-Type of application/json for some requests.
+            raw_body = request.get_data()
             if (
                 FLASK_ENV != "test"
+                # HACK: The signature header may be one of these two values
                 and not is_correct_sentry_signature(
-                    body=request.get_data(),
+                    body=raw_body,
                     key=SENTRY_CLIENT_SECRET,
                     expected=request.headers.get("sentry-hook-signature")
                 )
                 and not is_correct_sentry_signature(
-                    body=request.get_data(),
+                    body=raw_body,
                     key=SENTRY_CLIENT_SECRET,
                     expected=request.headers.get("sentry-app-signature")
                 )

--- a/backend-ts/src/api/middleware/verifySentrySignature.ts
+++ b/backend-ts/src/api/middleware/verifySentrySignature.ts
@@ -1,19 +1,26 @@
 import {createHmac} from 'crypto';
 import {NextFunction, Request, Response} from 'express';
 
+// There are few hacks in this verification step (denoted with HACK) that we at Sentry hope
+// to migrate away from in the future. Presently however, for legacy reasons, they are
+// necessary to keep around, so we've shown how to deal with them here.
+
 function getSignatureBody(req: Request): string {
   const stringifiedBody = JSON.stringify(req.body);
+  // HACK: This is necessary since express.json() converts the empty request body to {}
   return stringifiedBody === '{}' ? '' : stringifiedBody;
 }
 
-// This function will authenticate that the requests are coming from Sentry.
-// Now, we can be confident in our nested routes that the data is legit,
-// without having to repeat this check.
 export default function verifySentrySignature(
   request: Request,
   response: Response,
   next: NextFunction
 ) {
+  /**
+   * This function will authenticate that the requests are coming from Sentry.
+   * It allows us to be confident that all the code run after this middleware are
+   * using verified data sent directly from Sentry.
+   */
   if (process.env.NODE_ENV == 'test') {
     return next();
   }
@@ -22,6 +29,7 @@ export default function verifySentrySignature(
   hmac.update(getSignatureBody(request), 'utf8');
   const digest = hmac.digest('hex');
   if (
+    // HACK: The signature header may be one of these two values
     digest === request.headers['sentry-hook-signature'] ||
     digest === request.headers['sentry-app-signature']
   ) {


### PR DESCRIPTION
This PR adds back the signature verification for all incoming requests. Unfortunately, it looks pretty hacky and fragile, but it is what some of our partners have to do if we don't migrate the scheme to a single header, and actual JSON payload.

This PR should serve as an argument in favour of standardizing the headers and payloads on our results.

---

**For more info on how this occurs, and why it's not great:**

Sentry is sending a `application/json` header, with a empty body (`b''` in python). In Flask, this will automatically respond with a 400 if you attempt `request.json`, and in Express, it automatically coerces the empty body into `{}` since that is valid JSON.

Since we use the app secret and the request body to create the header, this leads to inconsistency with how developers are expected to parse the body, forcing them to always use the raw body since early stage middlewares or helpers (`request.json`, `bodyParser.json()`) might alter the payload. 

It's difficult to do that in JavaScript since the rest of the API consumes JSON requests, so I manually have to check for `req.body === {}` and convert it to `'' `. In Flask, I can't use `request.json` and have to `request.data` to access the raw byte string, but this is only because the header isn't telling the truth about the `Content-Type`.

Additionally, due to a typo in Sentry code, we have two headers which may or may not have the signature to verify against.