### PR TITLE
fix(comments): Ensure new comments are saved along side existing ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo '>>> Debugging'
 	@echo 'make setup-python        -> Rebuild the python backend with updated dependencies and environment variables'
 	@echo 'make setup-typescript    -> Rebuild the typescript backend with updated dependencies and environment variables'
-	@echo 'make seed-db             -> Manually seed the database with test data'
+	@echo 'make seed-db             -> Initialize the database with test data (Note: requires "make teardown" execution beforehand)'
 	@echo 'make dump-db             -> Replace the data in the seed file with the current database'
 	@echo 'make reset-db            -> Empty out the current database'
 	@echo 'make teardown            -> Stop all ongoing processes and remove their data (Note: erases the database)'

--- a/backend-py/src/api/endpoints/sentry/handlers/comment_handler.py
+++ b/backend-py/src/api/endpoints/sentry/handlers/comment_handler.py
@@ -8,7 +8,7 @@ from src.database import db_session
 
 
 def handle_created(item: Item, comment: ItemComment) -> Response:
-    item.comments = item.comments or [] + [comment]
+    item.comments = (item.comments or []) + [comment]
     db_session.commit()
     app.logger.info("Added new comment from Sentry issue")
     return Response('', 201)


### PR DESCRIPTION
Found a bug while demo-ing in which new comments weren't being saved on the Python backend. Fun parentheses issue. Also addresses some confusing behaviour in the debugging comments.