### PR TITLE
fix(middleware): use constant-time compare on hmac signature

### DIFF
--- a/backend-py/src/api/middleware/verify_sentry_signature.py
+++ b/backend-py/src/api/middleware/verify_sentry_signature.py
@@ -29,7 +29,7 @@ def is_correct_sentry_signature(
         digestmod=hashlib.sha256,
     ).hexdigest()
 
-    if digest != expected:
+    if not hmac.compare_digest(digest, expected):
         return False
 
     app.logger.info("Authorized: Verified request came from Sentry")

--- a/backend-py/src/api/middleware/verify_sentry_signature.py
+++ b/backend-py/src/api/middleware/verify_sentry_signature.py
@@ -23,6 +23,12 @@ SENTRY_CLIENT_SECRET = os.getenv("SENTRY_CLIENT_SECRET")
 def is_correct_sentry_signature(
     body: Mapping[str, Any], key: str, expected: str
 ) -> bool:
+    # expected could be `None` if the header was missing,
+    # in which case we return early as the request is invalid
+    # without a signature
+    if not expected:
+        return False
+
     digest = hmac.new(
         key=key.encode("utf-8"),
         msg=body,


### PR DESCRIPTION
A small fix to use a constant-time comparison on the HMAC signatures for the webhook payloads. Using the constant-time compare will help defend against timing attacks.