### PR TITLE
fix(ci): Match files deeper than the root of a dir

### DIFF
--- a/.github/workflows/backend-py.yml
+++ b/.github/workflows/backend-py.yml
@@ -4,7 +4,7 @@ on:
     paths:
       - ".github/actions/setup-test"
       - ".github/workflows/backend-py.yml"
-      - "backend-py/*"
+      - "backend-py/**"
   push:
     branches:
       - main

--- a/.github/workflows/backend-ts.yml
+++ b/.github/workflows/backend-ts.yml
@@ -2,9 +2,9 @@ name: backend-ts
 on:
   pull_request:
     paths:
-      - ".github/actions/*"
+      - ".github/actions/**"
       - ".github/workflows/backend-ts.yml"
-      - "backend-ts/*"
+      - "backend-ts/**"
   push:
     branches:
       - main

--- a/.github/workflows/frontend-ts.yml
+++ b/.github/workflows/frontend-ts.yml
@@ -2,9 +2,9 @@ name: frontend
 on:
   pull_request:
     paths:
-      - ".github/actions/*"
+      - ".github/actions/**"
       - ".github/workflows/frontend-ts.yml"
-      - "frontend/*"
+      - "frontend/**"
   push:
     branches:
       - main


### PR DESCRIPTION
From the docs:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths

```text
docs/*      All files within the root of the docs directory, at the root of the repository.
            e.g.: docs/README.md docs/file.txt
docs/**     Any files in the /docs directory at the root of the repository.
            e.g.: docs/README.md docs/mona/octocat.txt
```