### PR TITLE
fix(ci): Pick specific Python version

### DIFF
--- a/.github/workflows/backend-py.yml
+++ b/.github/workflows/backend-py.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.9"
 
       - uses: "./.github/actions/setup-test"
 


### PR DESCRIPTION
A new version of Python was releasing recently (3.11.0), thus, at least a package does not install for it.