### PR TITLE
chore(hybrid-cloud): Updates TS issue API request to include sentry org slug

### DIFF
--- a/backend-ts/src/api/items.ts
+++ b/backend-ts/src/api/items.ts
@@ -15,7 +15,7 @@ async function addSentryAPIData(
     organization.items.map(async item => {
       if (item.sentryId) {
         // Use the numerical ID to fetch the short ID
-        const sentryData = await sentry.get(`/issues/${item.sentryId}/`);
+        const sentryData = await sentry.get(`/organizations/${organization.externalSlug}/issues/${item.sentryId}/`);
         // Replace the numerical ID with the short ID
         const shortId = (sentryData || {})?.data?.shortId;
         if (shortId) {


### PR DESCRIPTION
Updates the example issues API request to include the sentry org slug in order to ensure requests are routed to the correct region. Looks like the backend-py code already uses the correct route, we just missed updating the TS backend.
